### PR TITLE
Add more control to plugin outputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,11 +38,26 @@ import "hardhat-generate-function-selectors";
 
 3. Add this to your hardhat.config.js as well:
 
+| option         | description                                                                                                                                                  | default          |
+| -------------- |--------------------------------------------------------------------------------------------------------------------------------------------------------------|------------------|
+| `separateContractSelectors`         | separate by contract                                                                                                                                         | `true`           |
+| `orderedByValue` | order function selectors by hex value, least to greatest                                                                                                      | `false`          |
+| `outputPath`        | directory where output file should be written                                                                                                     | `./`             |
+| `outputFilename`         | filename of generated output                                                                                              | `selectors.json` |
+| `pretty`         | pretty print the output JSON(s)                                                   | `true`           |
+| `runOnCompile`       | run the selectors task on compile                                                                                                   | `true`           |
+| `includeParams`      | include the parameters in the selector title (outputs only)                                                                                                 | `true`           |
+| `only`       | Array of String matchers used to select included contracts, defaults to all contracts if length is 0                                                                                  | `[]`             |
+| `except`       | Array of String matchers used to exclude contracts                                                                                   | `[]`             |
+| `skipSelectors`       | Array of selectors to be excluded from generated output | `[]`             |
+
+
 ```bash
 <your hardhat config> = {
   functionSelectors: {
-    separateContractSelectors: true, //separate by contract
-    orderedByValue: true, //order function selectors by hex value, least to greatest
+    separateContractSelectors: true, 
+    orderedByValue: true,
+    <other optional params>
   },
 };
 ```

--- a/README.md
+++ b/README.md
@@ -38,18 +38,17 @@ import "hardhat-generate-function-selectors";
 
 3. Add this to your hardhat.config.js as well:
 
-| option         | description                                                                                                                                                  | default          |
-| -------------- |--------------------------------------------------------------------------------------------------------------------------------------------------------------|------------------|
-| `separateContractSelectors`         | separate by contract                                                                                                                                         | `true`           |
-| `orderedByValue` | order function selectors by hex value, least to greatest                                                                                                      | `false`          |
-| `outputPath`        | directory where output file should be written                                                                                                     | `./`             |
-| `outputFilename`         | filename of generated output                                                                                              | `selectors.json` |
-| `pretty`         | pretty print the output JSON(s)                                                   | `true`           |
-| `runOnCompile`       | run the selectors task on compile                                                                                                   | `true`           |
-| `includeParams`      | include the parameters in the selector title (outputs only)                                                                                                 | `true`           |
-| `only`       | Array of String matchers used to select included contracts, defaults to all contracts if length is 0                                                                                  | `[]`             |
-| `except`       | Array of String matchers used to exclude contracts                                                                                   | `[]`             |
-| `skipSelectors`       | Array of selectors to be excluded from generated output | `[]`             |
+| option         | description                                                                                          | default            |
+| -------------- |------------------------------------------------------------------------------------------------------|--------------------|
+| `separateContractSelectors`         | separate by contract                                                                                 | `true`             |
+| `orderedByValue` | order function selectors by hex value, least to greatest                                             | `false`            |
+| `outputPath`        | directory including filename where output file should be written                                     | `./selectors.json` |
+| `pretty`         | pretty print the output JSON(s)                                                                      | `true`             |
+| `runOnCompile`       | run the selectors task on compile                                                                    | `true`             |
+| `includeParams`      | include the parameters in the selector title (outputs only)                                          | `true`             |
+| `only`       | Array of String matchers used to select included contracts, defaults to all contracts if length is 0 | `[]`               |
+| `except`       | Array of String matchers used to exclude contracts                                                   | `[]`               |
+| `skipSelectors`       | Array of selectors to be excluded from generated output                                              | `[]`               |
 
 
 ```bash

--- a/index.ts
+++ b/index.ts
@@ -48,16 +48,13 @@ declare module "hardhat/types/config" {
 }
 
 const DEFAULT_CONFIG : FunctionSelectorsConfigEntry = {
-    separateContractSelectors: false, // separate by contract
-    orderedByValue: false, // order function selectors by hex value, least to greatest
-
-    outputPath: "'",
+    separateContractSelectors: true,
+    orderedByValue: false,
+    outputPath: ".",
     outputFilename: "selectors.json",
-
-    pretty: true, // pretty print the output JSON(s)
-    runOnCompile: true, // run the selectors task on compile
-    includeParams: true, // include the parameters in the selector title (outputs only)
-
+    pretty: true,
+    runOnCompile: true,
+    includeParams: true,
     only: [],
     except: [],
     skipSelectors: [],

--- a/index.ts
+++ b/index.ts
@@ -1,5 +1,5 @@
-
 import {extendConfig} from "hardhat/config"
+import {HardhatPluginError} from "hardhat/plugins";
 import "@nomiclabs/hardhat-ethers"
 import 'hardhat/types/config';
 import './tasks/compile';
@@ -10,7 +10,6 @@ interface FunctionSelectorsUserConfigEntry {
     orderedByValue?: boolean
 
     outputPath?: string,
-    outputFilename?: string,
 
     pretty?: boolean
     runOnCompile?: boolean
@@ -26,7 +25,6 @@ export interface FunctionSelectorsConfigEntry {
     orderedByValue: boolean
 
     outputPath: string,
-    outputFilename: string,
 
     pretty: boolean
     runOnCompile: boolean
@@ -50,8 +48,7 @@ declare module "hardhat/types/config" {
 const DEFAULT_CONFIG : FunctionSelectorsConfigEntry = {
     separateContractSelectors: true,
     orderedByValue: false,
-    outputPath: ".",
-    outputFilename: "selectors.json",
+    outputPath: "./selectors.json",
     pretty: true,
     runOnCompile: true,
     includeParams: true,
@@ -62,7 +59,36 @@ const DEFAULT_CONFIG : FunctionSelectorsConfigEntry = {
 
 extendConfig((config, userConfig) => {
     config.functionSelectors = [userConfig.functionSelectors].flat().map((el) => {
+        // if any values not provided by user, go with defaults
         const conf = Object.assign({}, DEFAULT_CONFIG, el)
+
+        // check if only/except have an overlap
+        const overlap = conf.only.filter(value => conf.except.includes(value))
+        if (overlap.length>0) {
+            throw new HardhatPluginError(
+                "function-selectors-plugin",
+                `\`only\` & \`except\` elements cannot overlap: [${overlap}]`,
+            );
+        }
+
+        // check if any selectors not correct len
+        const incorrectLen = conf.skipSelectors.filter((sel) => sel.length !== 10)
+        if(incorrectLen.length > 0){
+            throw new HardhatPluginError(
+                "function-selectors-plugin",
+                `selectors in \`skipSelectors\` must be 10 characters: [${incorrectLen}]`,
+            );
+        }
+
+        // check if any selectors don't start with "0x"
+        const incorrectPrefix = conf.skipSelectors.filter((sel) => !sel.startsWith("0x"))
+        if(incorrectLen.length > 0){
+            throw new HardhatPluginError(
+                "function-selectors-plugin",
+                `selectors in \`skipSelectors\` must be start with a \`0x\`: [${incorrectPrefix}]`,
+            );
+        }
+
         return conf as FunctionSelectorsConfigEntry
     })
 })

--- a/index.ts
+++ b/index.ts
@@ -1,141 +1,198 @@
-import { extendEnvironment } from "hardhat/config";
-import { task } from "hardhat/config";
-import * as fs from "fs";
-import * as path from "path";
-import "@nomiclabs/hardhat-ethers";
+import {TASK_COMPILE} from 'hardhat/builtin-tasks/task-names';
+import {extendEnvironment, task} from "hardhat/config"
+import * as fs from "fs"
+import "@nomiclabs/hardhat-ethers"
+import {HardhatRuntimeEnvironment} from "hardhat/types";
 
-interface CustomHardhatConfig {
-  separateContractSelectors?: boolean;
-  orderedByValue?: boolean;
+interface FunctionSelectorsConfig {
+    separateContractSelectors?: boolean
+    orderedByValue?: boolean
+
+    outputPath?: string,
+    outputFilename?: string,
+
+    pretty?: boolean
+    runOnCompile?: boolean
+    includeParams?: boolean
+
+    only?: string[]
+    except?: string[]
+    skipSelectors?: string[]
 }
 
 declare module "hardhat/types/config" {
-  interface HardhatUserConfig {
-    functionSelectors?: CustomHardhatConfig;
-  }
-  interface HardhatConfig {
-    functionSelectors: CustomHardhatConfig;
-  }
+    interface HardhatUserConfig {
+        functionSelectors?: FunctionSelectorsConfig
+    }
+
+    interface HardhatConfig {
+        functionSelectors: FunctionSelectorsConfig
+    }
 }
 
-extendEnvironment((hre) => {
-  hre.selectors = async () => {
+function sortDict<T>(dict: { [key: string]: T }): { [key: string]: T } {
+    return Object.keys(dict)
+        .sort()
+        .reduce((obj, key) => {
+            obj[key] = dict[key]
+            return obj
+        }, {} as { [key: string]: T })
+}
+
+function checkConfigExists(hre: HardhatRuntimeEnvironment) {
     if (!hre.config.functionSelectors) {
-      throw new Error(`Missing \`functionSelectors\` configuration in Hardhat config. 
+        throw new Error(`Missing \`functionSelectors\` configuration in Hardhat config. 
         An example configuration looks like this:
 
         module.exports = {
           functionSelectors: {
             separateContractSelectors: true, // separate by contract
             orderedByValue: true, // order function selectors by hex value, least to greatest
+            
+            outputPath: ".",
+            outputFilename: "selectors.json",
+            
+            pretty: true, // pretty print the output JSON(s)
+            runOnCompile: true, // run the selectors task on compile
+            includeParams: true, // include the parameters in the selector title (outputs only)
+            
+            only: [],
+            except: [],
+            skipSelectors: [],
           },
           // other configurations...
-        };
-      `);
-    }
-
-    const separateContractSelectors =
-      hre.config.functionSelectors.separateContractSelectors || false;
-    const orderedByValue = hre.config.functionSelectors.orderedByValue || false;
-
-    const artifactsDir = path.join(hre.config.paths.artifacts, "/contracts");
-
-    // Initialize an object to store all contracts selectors
-    let contractsSelectors: {
-      [contract: string]: { [selector: string]: string };
-    } = {};
-
-    const processDirectory = (directory: string) => {
-      const files = fs.readdirSync(directory);
-
-      for (let file of files) {
-        const filePath = path.join(directory, file);
-
-        if (fs.lstatSync(filePath).isDirectory()) {
-          processDirectory(filePath);
-        } else if (
-          path.extname(file) === ".json" &&
-          !file.endsWith(".dbg.json")
-        ) {
-          const contractName = path.basename(file, ".json");
-          const artifact = JSON.parse(fs.readFileSync(filePath, "utf8"));
-          const abi = artifact.abi;
-
-          if (separateContractSelectors) {
-            contractsSelectors[contractName] = {};
-          }
-
-          for (let item of abi) {
-            if (item.type === "function") {
-              const abiCoder = new hre.ethers.utils.AbiCoder();
-              const packedData = abiCoder.encode(
-                ["string"],
-                [
-                  `${item.name}(${item.inputs
-                    .map((i: any) => i.type)
-                    .join(",")})`,
-                ]
-              );
-
-              const signature = hre.ethers.utils.keccak256(packedData);
-              const selector = signature.slice(0, 10);
-
-              // Save the selector under the corresponding contract if enabled
-              if (separateContractSelectors) {
-                contractsSelectors[contractName][selector] = item.name;
-              } else {
-                contractsSelectors[selector] = item.name;
-              }
-            }
-          }
         }
-      }
-    };
-
-    processDirectory(artifactsDir);
-
-    // Ordering function selectors by their hex value if enabled
-    if (orderedByValue) {
-      for (let contract in contractsSelectors) {
-        const unorderedSelectors = contractsSelectors[contract];
-        const orderedSelectors = Object.keys(unorderedSelectors)
-          .sort()
-          .reduce((obj, key) => {
-            obj[key] = unorderedSelectors[key];
-            return obj;
-          }, {} as { [selector: string]: string });
-
-        contractsSelectors[contract] = orderedSelectors;
-      }
+      `)
     }
+}
 
-    // Write the contracts' selectors to a file
-    fs.writeFileSync(
-      "selectors.json",
-      JSON.stringify(contractsSelectors, null, 2)
-    );
+extendEnvironment((hre: HardhatRuntimeEnvironment) => {
+    hre.selectors = async () => {
+        const args = hre.config.functionSelectors
 
-    console.log("Function selectors have been written to selectors.json");
-  };
-});
+        const separateContractSelectors = args.separateContractSelectors || false
+        const orderedByValue = args.orderedByValue || false
+        const outputPath = args.outputPath || "."
+        const outputFilename = args.outputFilename || "selectors.json"
+        const prettyPrint = args.pretty || false
+        const includeParams = args.includeParams || true
+
+        const outFile = `${outputPath}/${outputFilename}`
+
+        const fullNames = await hre.artifacts.getAllFullyQualifiedNames()
+
+        const abiCoder = new hre.ethers.utils.AbiCoder()
+
+        // Initialize an object to store all contracts selectors
+        let contractsSelectors: {
+            [contract: string]: { [selector: string]: string }
+        } = {}
+
+        await Promise.all(
+            fullNames.map(async (fullName) => {
+                // if limiting with only, skip if not matching some expression
+                if (args.only && args.only.length && !args.only.some((m) => fullName.match(m)))
+                    return [fullName, {}]
+                // if limiting with except, skip if matching some expression
+                if (args.except && args.except.length && args.except.some((m) => fullName.match(m)))
+                    return [fullName, {}]
+
+                // load the artifact
+                let {abi, contractName} = await hre.artifacts.readArtifact(fullName)
+
+                // if abi has no functions, it's not worth persisting
+                if (!abi.some((item) => item.type === "function")) {
+                    return
+                }
+
+                contractsSelectors[contractName] = {}
+
+                for (let item of abi) {
+                    if (item.type === "function") {
+                        const functionDef = `${item.name}(${item.inputs.map((i: any) => i.type).join(",")})`
+
+                        const persistedSelectorTitle = includeParams ? functionDef : item.name
+
+                        const signature = hre.ethers.utils.keccak256(
+                            abiCoder.encode(["string"], [functionDef])
+                        )
+
+                        const selector = signature.slice(0, 10)
+
+                        // check if this selector is in the skip list
+                        if (args.skipSelectors && args.skipSelectors.length && args.skipSelectors.some((m) => selector.match(m)))
+                            continue
+
+                        contractsSelectors[contractName][selector] = persistedSelectorTitle
+                    }
+                }
+            })
+        )
+
+        // optionally flatten the contracts/selectors
+        let outputSelectors: {
+            [contract: string]: { [selector: string]: string } | string
+        } = separateContractSelectors
+            // if separating, use already split contracts/selectors
+            ? contractsSelectors
+            // if not separating, flatten the selectors into 1 object
+            : Object.values(contractsSelectors)
+                .reduce((acc, selectors) => ({...acc, ...selectors}), {});
+
+        // Ordering function selectors by their hex value if enabled
+        if (orderedByValue) {
+            outputSelectors = separateContractSelectors
+                // sort the selectors associated with each contract
+                ? Object.fromEntries(
+                    Object.entries(contractsSelectors).map(
+                        ([contract, selectors]) => [contract, sortDict(selectors)]
+                    )
+                )
+                // sort all the selectors
+                : sortDict(outputSelectors);
+        }
+
+        const writeData = prettyPrint ? JSON.stringify(outputSelectors, null, 2) : JSON.stringify(outputSelectors)
+
+        fs.mkdirSync(outputPath, {recursive: true})
+
+        // Write the contracts' selectors to a file
+        fs.writeFileSync(outFile, writeData)
+
+        console.log(`Function selectors have been written to ${outFile}`)
+    }
+})
 
 // Define a new task that uses your plugin
 task(
-  "selectors",
-  "Generate a file of function selectors",
-  async (args, hre) => {
-    await hre.selectors();
-  }
-);
+    "selectors",
+    "Generate a file of function selectors",
+    async (args, hre) => {
+        checkConfigExists(hre)
+        await hre.selectors()
+    }
+)
+
+// extend the compilation task to optionally generate selectors on each compile
+task(TASK_COMPILE)
+    .setAction(async (args, hre, runSuper) => {
+        await runSuper()
+        if (!(hre as any).__SOLIDITY_COVERAGE_RUNNING) {
+            checkConfigExists(hre)
+            if (hre.config.functionSelectors.runOnCompile) {
+                await hre.selectors()
+            }
+        }
+    })
 
 // This is needed for TypeScript not to complain about the hre.selectors() field
 declare module "hardhat/types/config" {
-  export interface HardhatUserConfig {
-    selectors?: () => Promise<void>;
-  }
+    export interface HardhatUserConfig {
+        selectors?: () => Promise<void>
+    }
 }
 declare module "hardhat/types/runtime" {
-  interface HardhatRuntimeEnvironment {
-    selectors: () => Promise<void>;
-  }
+    interface HardhatRuntimeEnvironment {
+        selectors: () => Promise<void>
+    }
 }

--- a/index.ts
+++ b/index.ts
@@ -1,10 +1,11 @@
-import {TASK_COMPILE} from 'hardhat/builtin-tasks/task-names';
-import {extendEnvironment, task} from "hardhat/config"
-import * as fs from "fs"
-import "@nomiclabs/hardhat-ethers"
-import {HardhatRuntimeEnvironment} from "hardhat/types";
 
-interface FunctionSelectorsConfig {
+import {extendConfig} from "hardhat/config"
+import "@nomiclabs/hardhat-ethers"
+import 'hardhat/types/config';
+import './tasks/compile';
+import './tasks/selectors';
+
+interface FunctionSelectorsUserConfigEntry {
     separateContractSelectors?: boolean
     orderedByValue?: boolean
 
@@ -20,179 +21,51 @@ interface FunctionSelectorsConfig {
     skipSelectors?: string[]
 }
 
+export interface FunctionSelectorsConfigEntry {
+    separateContractSelectors: boolean
+    orderedByValue: boolean
+
+    outputPath: string,
+    outputFilename: string,
+
+    pretty: boolean
+    runOnCompile: boolean
+    includeParams: boolean
+
+    only: string[]
+    except: string[]
+    skipSelectors: string[]
+}
+
 declare module "hardhat/types/config" {
     interface HardhatUserConfig {
-        functionSelectors?: FunctionSelectorsConfig
+        functionSelectors?: FunctionSelectorsUserConfigEntry | FunctionSelectorsUserConfigEntry[]
     }
 
     interface HardhatConfig {
-        functionSelectors: FunctionSelectorsConfig
+        functionSelectors: FunctionSelectorsConfigEntry[]
     }
 }
 
-function sortDict<T>(dict: { [key: string]: T }): { [key: string]: T } {
-    return Object.keys(dict)
-        .sort()
-        .reduce((obj, key) => {
-            obj[key] = dict[key]
-            return obj
-        }, {} as { [key: string]: T })
+const DEFAULT_CONFIG : FunctionSelectorsConfigEntry = {
+    separateContractSelectors: false, // separate by contract
+    orderedByValue: false, // order function selectors by hex value, least to greatest
+
+    outputPath: "'",
+    outputFilename: "selectors.json",
+
+    pretty: true, // pretty print the output JSON(s)
+    runOnCompile: true, // run the selectors task on compile
+    includeParams: true, // include the parameters in the selector title (outputs only)
+
+    only: [],
+    except: [],
+    skipSelectors: [],
 }
 
-function checkConfigExists(hre: HardhatRuntimeEnvironment) {
-    if (!hre.config.functionSelectors) {
-        throw new Error(`Missing \`functionSelectors\` configuration in Hardhat config. 
-        An example configuration looks like this:
-
-        module.exports = {
-          functionSelectors: {
-            separateContractSelectors: true, // separate by contract
-            orderedByValue: true, // order function selectors by hex value, least to greatest
-            
-            outputPath: ".",
-            outputFilename: "selectors.json",
-            
-            pretty: true, // pretty print the output JSON(s)
-            runOnCompile: true, // run the selectors task on compile
-            includeParams: true, // include the parameters in the selector title (outputs only)
-            
-            only: [],
-            except: [],
-            skipSelectors: [],
-          },
-          // other configurations...
-        }
-      `)
-    }
-}
-
-extendEnvironment((hre: HardhatRuntimeEnvironment) => {
-    hre.selectors = async () => {
-        const args = hre.config.functionSelectors
-
-        const separateContractSelectors = args.separateContractSelectors || false
-        const orderedByValue = args.orderedByValue || false
-        const outputPath = args.outputPath || "."
-        const outputFilename = args.outputFilename || "selectors.json"
-        const prettyPrint = args.pretty || false
-        const includeParams = args.includeParams || true
-
-        const outFile = `${outputPath}/${outputFilename}`
-
-        const fullNames = await hre.artifacts.getAllFullyQualifiedNames()
-
-        const abiCoder = new hre.ethers.utils.AbiCoder()
-
-        // Initialize an object to store all contracts selectors
-        let contractsSelectors: {
-            [contract: string]: { [selector: string]: string }
-        } = {}
-
-        await Promise.all(
-            fullNames.map(async (fullName) => {
-                // if limiting with only, skip if not matching some expression
-                if (args.only && args.only.length && !args.only.some((m) => fullName.match(m)))
-                    return [fullName, {}]
-                // if limiting with except, skip if matching some expression
-                if (args.except && args.except.length && args.except.some((m) => fullName.match(m)))
-                    return [fullName, {}]
-
-                // load the artifact
-                let {abi, contractName} = await hre.artifacts.readArtifact(fullName)
-
-                // if abi has no functions, it's not worth persisting
-                if (!abi.some((item) => item.type === "function")) {
-                    return
-                }
-
-                contractsSelectors[contractName] = {}
-
-                for (let item of abi) {
-                    if (item.type === "function") {
-                        const functionDef = `${item.name}(${item.inputs.map((i: any) => i.type).join(",")})`
-
-                        const persistedSelectorTitle = includeParams ? functionDef : item.name
-
-                        const signature = hre.ethers.utils.keccak256(
-                            abiCoder.encode(["string"], [functionDef])
-                        )
-
-                        const selector = signature.slice(0, 10)
-
-                        // check if this selector is in the skip list
-                        if (args.skipSelectors && args.skipSelectors.length && args.skipSelectors.some((m) => selector.match(m)))
-                            continue
-
-                        contractsSelectors[contractName][selector] = persistedSelectorTitle
-                    }
-                }
-            })
-        )
-
-        // optionally flatten the contracts/selectors
-        let outputSelectors: {
-            [contract: string]: { [selector: string]: string } | string
-        } = separateContractSelectors
-            // if separating, use already split contracts/selectors
-            ? contractsSelectors
-            // if not separating, flatten the selectors into 1 object
-            : Object.values(contractsSelectors)
-                .reduce((acc, selectors) => ({...acc, ...selectors}), {});
-
-        // Ordering function selectors by their hex value if enabled
-        if (orderedByValue) {
-            outputSelectors = separateContractSelectors
-                // sort the selectors associated with each contract
-                ? Object.fromEntries(
-                    Object.entries(contractsSelectors).map(
-                        ([contract, selectors]) => [contract, sortDict(selectors)]
-                    )
-                )
-                // sort all the selectors
-                : sortDict(outputSelectors);
-        }
-
-        const writeData = prettyPrint ? JSON.stringify(outputSelectors, null, 2) : JSON.stringify(outputSelectors)
-
-        fs.mkdirSync(outputPath, {recursive: true})
-
-        // Write the contracts' selectors to a file
-        fs.writeFileSync(outFile, writeData)
-
-        console.log(`Function selectors have been written to ${outFile}`)
-    }
-})
-
-// Define a new task that uses your plugin
-task(
-    "selectors",
-    "Generate a file of function selectors",
-    async (args, hre) => {
-        checkConfigExists(hre)
-        await hre.selectors()
-    }
-)
-
-// extend the compilation task to optionally generate selectors on each compile
-task(TASK_COMPILE)
-    .setAction(async (args, hre, runSuper) => {
-        await runSuper()
-        if (!(hre as any).__SOLIDITY_COVERAGE_RUNNING) {
-            checkConfigExists(hre)
-            if (hre.config.functionSelectors.runOnCompile) {
-                await hre.selectors()
-            }
-        }
+extendConfig((config, userConfig) => {
+    config.functionSelectors = [userConfig.functionSelectors].flat().map((el) => {
+        const conf = Object.assign({}, DEFAULT_CONFIG, el)
+        return conf as FunctionSelectorsConfigEntry
     })
-
-// This is needed for TypeScript not to complain about the hre.selectors() field
-declare module "hardhat/types/config" {
-    export interface HardhatUserConfig {
-        selectors?: () => Promise<void>
-    }
-}
-declare module "hardhat/types/runtime" {
-    interface HardhatRuntimeEnvironment {
-        selectors: () => Promise<void>
-    }
-}
+})

--- a/index.ts
+++ b/index.ts
@@ -8,13 +8,10 @@ import './tasks/selectors';
 interface FunctionSelectorsUserConfigEntry {
     separateContractSelectors?: boolean
     orderedByValue?: boolean
-
-    outputPath?: string,
-
     pretty?: boolean
     runOnCompile?: boolean
     includeParams?: boolean
-
+    outputPath?: string,
     only?: string[]
     except?: string[]
     skipSelectors?: string[]
@@ -23,13 +20,10 @@ interface FunctionSelectorsUserConfigEntry {
 export interface FunctionSelectorsConfigEntry {
     separateContractSelectors: boolean
     orderedByValue: boolean
-
-    outputPath: string,
-
     pretty: boolean
     runOnCompile: boolean
     includeParams: boolean
-
+    outputPath: string,
     only: string[]
     except: string[]
     skipSelectors: string[]

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hardhat-generate-function-selectors",
-  "version": "1.17.1",
+  "version": "1.18.1",
   "description": "A Hardhat plugin to generate function selectors from Solidity contracts.",
   "main": "./dist/cjs/index.js",
   "module": "./dist/esm/index.js",

--- a/tasks/compile.ts
+++ b/tasks/compile.ts
@@ -1,0 +1,24 @@
+import {TASK_COMPILE} from 'hardhat/builtin-tasks/task-names';
+import {task} from "hardhat/config"
+import {checkConfigExists} from "../tools";
+import "../index";
+
+// extend the compilation task to optionally generate selectors on each compile
+task(TASK_COMPILE)
+    .setAction(async (args, hre, runSuper) => {
+        if (!(hre as any).__SOLIDITY_COVERAGE_RUNNING) {
+
+            checkConfigExists(hre)
+
+            const configs = hre.config.functionSelectors;
+
+            await Promise.all(
+                configs.map((abiGroupConfig) => {
+                    if (abiGroupConfig.runOnCompile) {
+                        return hre.run('export-selectors-group', { abiGroupConfig });
+                    }
+                }),
+            );
+        }
+        await runSuper()
+    })

--- a/tasks/selectors.ts
+++ b/tasks/selectors.ts
@@ -1,0 +1,117 @@
+import {task, subtask, types} from "hardhat/config"
+import {checkConfigExists, sortDict} from "../tools";
+import {FunctionSelectorsConfigEntry} from "../index";
+import fs from "fs";
+
+task('selectors')
+    .setAction(async (args, hre) => {
+
+        checkConfigExists(hre)
+
+        const configs = hre.config.functionSelectors;
+
+        await Promise.all(
+            configs.map((abiGroupConfig) => {
+                return hre.run('export-selectors-group', { abiGroupConfig });
+            }),
+        );
+    });
+
+// Define a new task that uses your plugin
+subtask(
+    "export-selectors-group",
+    "Generate a file of function selectors"
+).addParam(
+    'abiGroupConfig',
+    'a single function-selectors-exporter config object',
+    undefined,
+    types.any,
+).setAction(async (args, hre) => {
+    const { abiGroupConfig: config } = args as {
+        abiGroupConfig: FunctionSelectorsConfigEntry;
+    };
+
+    const outFile = `${config.outputPath}/${config.outputFilename}`
+
+    const fullNames = await hre.artifacts.getAllFullyQualifiedNames()
+
+    const abiCoder = new hre.ethers.utils.AbiCoder()
+
+    // Initialize an object to store all contracts selectors
+    let contractsSelectors: {
+        [contract: string]: { [selector: string]: string }
+    } = {}
+
+    await Promise.all(
+        fullNames.map(async (fullName) => {
+            // if limiting with only, skip if not matching some expression
+            if (config.only && config.only.length && !config.only.some((m) => fullName.match(m)))
+                return [fullName, {}]
+            // if limiting with except, skip if matching some expression
+            if (config.except && config.except.length && config.except.some((m) => fullName.match(m)))
+                return [fullName, {}]
+
+            // load the artifact
+            let {abi, contractName} = await hre.artifacts.readArtifact(fullName)
+
+            // if abi has no functions, it's not worth persisting
+            if (!abi.some((item) => item.type === "function")) {
+                return
+            }
+
+            contractsSelectors[contractName] = {}
+
+            for (let item of abi) {
+                if (item.type === "function") {
+                    const functionDef = `${item.name}(${item.inputs.map((i: any) => i.type).join(",")})`
+
+                    const persistedSelectorTitle = config.includeParams ? functionDef : item.name
+
+                    const signature = hre.ethers.utils.keccak256(
+                        abiCoder.encode(["string"], [functionDef])
+                    )
+
+                    const selector = signature.slice(0, 10)
+
+                    // check if this selector is in the skip list
+                    if (config.skipSelectors && config.skipSelectors.length && config.skipSelectors.some((m) => selector.match(m)))
+                        continue
+
+                    contractsSelectors[contractName][selector] = persistedSelectorTitle
+                }
+            }
+        })
+    )
+
+    // optionally flatten the contracts/selectors
+    let outputSelectors: {
+        [contract: string]: { [selector: string]: string } | string
+    } = config.separateContractSelectors
+        // if separating, use already split contracts/selectors
+        ? contractsSelectors
+        // if not separating, flatten the selectors into 1 object
+        : Object.values(contractsSelectors)
+            .reduce((acc, selectors) => ({...acc, ...selectors}), {});
+
+    // Ordering function selectors by their hex value if enabled
+    if (config.orderedByValue) {
+        outputSelectors = config.separateContractSelectors
+            // sort the selectors associated with each contract
+            ? Object.fromEntries(
+                Object.entries(contractsSelectors).map(
+                    ([contract, selectors]) => [contract, sortDict(selectors)]
+                )
+            )
+            // sort all the selectors
+            : sortDict(outputSelectors);
+    }
+
+    const writeData = config.pretty ? JSON.stringify(outputSelectors, null, 2) : JSON.stringify(outputSelectors)
+
+    fs.mkdirSync(config.outputPath, {recursive: true})
+
+    // Write the contracts' selectors to a file
+    fs.writeFileSync(outFile, writeData)
+
+    console.log(`Function selectors have been written to ${outFile}`)
+})

--- a/tools.ts
+++ b/tools.ts
@@ -1,0 +1,38 @@
+import {HardhatRuntimeEnvironment} from "hardhat/types";
+
+
+export function checkConfigExists(hre: HardhatRuntimeEnvironment) {
+    if (!hre.config.functionSelectors) {
+        throw new Error(`Missing \`functionSelectors\` configuration in Hardhat config. 
+        An example configuration looks like this:
+
+        module.exports = {
+          functionSelectors: {
+            separateContractSelectors: true, // separate by contract
+            orderedByValue: true, // order function selectors by hex value, least to greatest
+            
+            outputPath: ".", // directory where output file should be written
+            outputFilename: "selectors.json", // filename of generated output
+            
+            pretty: true, // pretty print the output JSON(s)
+            runOnCompile: true, // run the selectors task on compile
+            includeParams: true, // include the parameters in the selector title (outputs only)
+            
+            only: [], // Array of String matchers used to select included contracts, defaults to all contracts if length is 0
+            except: [], // Array of String matchers used to exclude contracts
+            skipSelectors: [], // Array of selectors to be excluded from generated output
+          },
+          // other configurations...
+        }
+      `)
+    }
+}
+
+export function sortDict<T>(dict: { [key: string]: T }): { [key: string]: T } {
+    return Object.keys(dict)
+        .sort()
+        .reduce((obj, key) => {
+            obj[key] = dict[key]
+            return obj
+        }, {} as { [key: string]: T })
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,7 +10,12 @@
     "composite": true,
     "moduleResolution": "node"
   },
-  "include": ["index.ts"],
-  "exclude": ["node_modules", "**/__tests__/*"],
+  "include": [
+    "index.ts",
+    "tools.ts",
+    "tasks/compile.ts",
+    "tasks/selectors.ts"
+  ],
+  "exclude": ["node_modules", "dist", "**/__tests__/*"],
   "references": [{ "path": "./tsconfig.cjs.json" }]
 }


### PR DESCRIPTION
Hello, I needed a bit more control over the outputs of the plugin so I made some updates for my purposes and thought the community could gain some benefit as well.

I added the following params to the config, and updated the `README.md`

| option         | description                                                                                          | default            |
| -------------- |------------------------------------------------------------------------------------------------------|--------------------|
| `outputPath`        | directory including filename where output file should be written| `./selectors.json` |
| `pretty`         | pretty print the output JSON(s)| `true`|
| `runOnCompile`       | run the selectors task on compile| `true`|
| `includeParams`      | include the parameters in the selector title (outputs only)| `true`|
| `only`       | Array of String matchers used to select included contracts, defaults to all contracts if length is 0 | `[]`|
| `except`       | Array of String matchers used to exclude contracts| `[]`|
| `skipSelectors`       | Array of selectors to be excluded from generated output| `[]`|

I've updated the `HardhatUserConfig` to handle either a singular config, or an array of configs in the case multiple outputs of different types need to be generated
```
interface HardhatUserConfig {
    functionSelectors?: FunctionSelectorsUserConfigEntry | FunctionSelectorsUserConfigEntry[]
}
```